### PR TITLE
348 - убрана галка Включать в командный интерфейс

### DIFF
--- a/src/cf/Subsystems/пбп_ПодключаемыеКоманды.xml
+++ b/src/cf/Subsystems/пбп_ПодключаемыеКоманды.xml
@@ -11,7 +11,7 @@
 			</Synonym>
 			<Comment/>
 			<IncludeHelpInContents>true</IncludeHelpInContents>
-			<IncludeInCommandInterface>true</IncludeInCommandInterface>
+			<IncludeInCommandInterface>false</IncludeInCommandInterface>
 			<UseOneCommand>false</UseOneCommand>
 			<Explanation/>
 			<Picture/>


### PR DESCRIPTION
убрана галка Включать в командный интерфейс

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Изменения конфигурации**
  * Подсистема "Подключаемые команды" больше не отображается в интерфейсе команд приложения. Эта подсистема была скрыта из интерфейса пользователя в соответствии с обновленной конфигурацией.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->