### PR TITLE
Облачное окружение разработки: статический анализ 1C/BSL (BSL Language Server)

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,5 @@
+{
+  "name": "PSSL — статический анализ 1C/BSL",
+  "user": "ubuntu",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Установка инструментов разработки для библиотеки PSSL.
+#
+# Ставит BSL Language Server (статический анализатор кода 1С/BSL) — тот же
+# анализатор, что используется на стадии SonarQube в CI. Скрипт идемпотентен:
+# при повторном запуске повторно ничего не скачивает, если нужная версия уже
+# установлена.
+#
+# Примечание: полный набор проверок проекта (edtValidate, syntaxCheck,
+# YAXUnit, BDD, smoke) выполняется через vanessa-runner и требует
+# проприетарной платформы 1С:Предприятие, которую нельзя установить без
+# лицензии, поэтому в это окружение она не входит.
+
+set -euo pipefail
+
+BSL_LS_VERSION="1.0.7"
+BSL_LS_DIR="/opt/bsl-language-server"
+BSL_LS_JAR="${BSL_LS_DIR}/bsl-language-server.jar"
+BSL_LS_URL="https://github.com/1c-syntax/bsl-language-server/releases/download/v${BSL_LS_VERSION}/bsl-language-server-${BSL_LS_VERSION}-exec.jar"
+
+echo ">>> Проверка Java..."
+if ! command -v java >/dev/null 2>&1; then
+  echo "ОШИБКА: java не найдена в PATH. BSL Language Server требует JRE 21+." >&2
+  exit 1
+fi
+java -version
+
+echo ">>> Установка BSL Language Server ${BSL_LS_VERSION}..."
+sudo mkdir -p "${BSL_LS_DIR}"
+sudo chown "$(id -u):$(id -g)" "${BSL_LS_DIR}"
+
+installed_version=""
+if [ -f "${BSL_LS_JAR}" ]; then
+  installed_version="$(java -jar "${BSL_LS_JAR}" --version 2>/dev/null | sed -n 's/^version: //p' || true)"
+fi
+
+if [ "${installed_version}" = "${BSL_LS_VERSION}" ]; then
+  echo "BSL Language Server ${BSL_LS_VERSION} уже установлен — пропускаем загрузку."
+else
+  echo "Загрузка ${BSL_LS_URL}"
+  curl -fsSL -o "${BSL_LS_JAR}" "${BSL_LS_URL}"
+fi
+
+echo ">>> Создание обёртки /usr/local/bin/bsl-ls..."
+sudo tee /usr/local/bin/bsl-ls >/dev/null <<'EOF'
+#!/usr/bin/env bash
+# Обёртка для запуска BSL Language Server.
+exec java -Xmx4g -jar /opt/bsl-language-server/bsl-language-server.jar "$@"
+EOF
+sudo chmod 0755 /usr/local/bin/bsl-ls
+
+echo ">>> Готово. Версия: $(bsl-ls --version)"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Что сделано

Настроено окружение Cloud Agent для этой библиотеки подсистем 1С (PSSL). Окружение является **repository-managed**: конфигурация хранится в репозитории и автоматически применяется будущими агентами после merge (без действий в dashboard).

Добавлен свободно запускаемый инструмент из pipeline проверки качества проекта — **BSL Language Server 1.0.7** (тот же анализатор, что используется на стадии SonarQube в CI).

### Изменения
- `.cursor/environment.json` — конфигурация окружения (`user: ubuntu`, `install`).
- `.cursor/install.sh` — идемпотентная установка BSL Language Server в `/opt/bsl-language-server` и обёртка `/usr/local/bin/bsl-ls`. Требует только JRE 21+ (уже есть в базовом образе).

### Как запускать анализ
```bash
bsl-ls analyze \
  --srcDir ./src/cf \
  --workspaceDir . \
  --configuration ./.bsl-language-server.json \
  --outputDir ./build/out/bsl-ls \
  --reporter json --reporter junit
```

## Проверка (end-to-end)

| Проверка | Результат |
| --- | --- |
| `install` с нуля | Загрузка jar + установка, exit 0 |
| `install` повторно (идемпотентность) | «уже установлен — пропускаем», exit 0 |
| Статический анализ `src/cf` | exit 0; 123 файла; 1509 замечаний (Information 810 / Warning 353 / Hint 331 / Error 15) |
| Отчёты | `bsl-json.json` (1.4M), `bsl-junit.xml` (393K) |
| Draft build (snapshot + install) | SUCCEEDED |
| Свежий Cloud Agent из build | PASS (Java 21, bsl-ls 1.0.7, 123 файла / 1509 замечаний, exit 0) |

## Ограничение окружения
Полный набор проверок проекта (`edtValidate`, `syntaxCheck`, `YAXUnit`, `BDD`, `smoke` через `vanessa-runner`/EDT) требует **проприетарной платформы 1С:Предприятие 8.3.23**, которую нельзя скачать/запустить в облачной VM без лицензии ITS. Это внешний блокер, не устранимый внутри VM. Поэтому в окружение включена только та часть pipeline, которая работает без лицензии — статический анализ BSL.

Инструментарий OneScript/`vrunner` намеренно не включён: актуальная линейка OneScript 2.x несовместима с зафиксированным в проекте тулчейном (`ВерсияСреды 1.4.0`, 4-значные версии в `packagedef`, ошибка типа в `logos`), а его основное назначение (инициализация ИБ и прогон тестов) всё равно упирается в отсутствие платформы 1С.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7aa9ffc4-bef5-41ef-8e39-20a8e5955711?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7aa9ffc4-bef5-41ef-8e39-20a8e5955711&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Добавлена автоматическая настройка окружения разработки.
  * Добавлена установка и запуск BSL Language Server версии 1.0.7.
  * Установка повторно использует уже загруженную версию и проверяет наличие Java.
  * Создана команда `bsl-ls` для запуска языкового сервера.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->